### PR TITLE
Bug fix for example - handle_async doesn't exist

### DIFF
--- a/examples/worker_async.py
+++ b/examples/worker_async.py
@@ -35,7 +35,7 @@ async def worker(context, task_data: Union[TaskRequest, TaskResult, TaskExceptio
 async def handle(request):
     handler = AsyncRequestReplyHandler(functions)
     request_data = await request.read()
-    response_data = await handler.handle_async(request_data)
+    response_data = await handler(request_data)
     return web.Response(body=response_data, content_type='application/octet-stream')
 
 async def app():


### PR DESCRIPTION
[AsyncRequestReplyHandler](https://github.com/apache/flink-statefun/blob/master/statefun-python-sdk/statefun/request_reply.py#L144) doesn't contain anything called handle_async.