### PR TITLE
Pipeline related fixes for issues #42, #43, #44.

### DIFF
--- a/docsrc/api/generated/statefun_tasks.TaskContext.rst
+++ b/docsrc/api/generated/statefun_tasks.TaskContext.rst
@@ -1,0 +1,36 @@
+﻿
+TaskContext
+==========================
+
+.. autoclass:: statefun_tasks.TaskContext
+   :members:
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+   .. autosummary::
+   
+      ~TaskContext.__init__
+      ~TaskContext.get_address
+      ~TaskContext.get_caller_address
+      ~TaskContext.get_caller_id
+      ~TaskContext.get_state
+      ~TaskContext.get_task_id
+      ~TaskContext.send_egress_message
+      ~TaskContext.send_message
+      ~TaskContext.send_message_after
+      ~TaskContext.set_state
+      ~TaskContext.to_address_and_id
+      ~TaskContext.update_state
+   
+    
+   
+
+   
+   
+
+   
+   
+   

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 
 setuptools.setup(
     name="statefun-tasks",
-    version="0.9.2",
+    version="0.9.3",
     author="Frans King",
     author_email="frans.king@sbbsystems.com",
     description="Tasks API for Stateful Functions on Flink",

--- a/statefun_tasks/pipeline.py
+++ b/statefun_tasks/pipeline.py
@@ -1,6 +1,5 @@
 from statefun_tasks.serialisation import DefaultSerialiser
 from statefun_tasks.messages_pb2 import TaskRequest, TaskResult, TaskResults, TaskException, TaskEntry, Pipeline
-from statefun_tasks.protobuf import pack_any, unpack_any
 from statefun_tasks.context import TaskContext
 from statefun_tasks.types import Task, Group, RetryPolicy
 from statefun_tasks.utils import _extend_args
@@ -64,13 +63,12 @@ class _Pipeline(object):
         caller_id = context.get_caller_id()
         state = context.get_state()
 
-        # mark pipeline step as complete
-        self._pipeline_helper.mark_task_complete(caller_id)
-
         # record the task result / exception - returns current map of task_id to task_result
         task_results = state.setdefault('task_results', TaskResults())
-        task_results.by_id[caller_id].CopyFrom(pack_any(task_result_or_exception))
-        
+
+        # mark pipeline step as complete
+        self._pipeline_helper.mark_task_complete(caller_id, task_result_or_exception, task_results)
+
         # save updated pipeline state
         context.update_state({'pipeline': self.to_proto()})
 

--- a/tests/test_parallel_workflow.py
+++ b/tests/test_parallel_workflow.py
@@ -5,6 +5,8 @@ from tests.utils import TestHarness, tasks, TaskErrorException
 
 
 join_results_called = False
+join_results2_called = False
+join_results3_called = False
 say_goodbye_called = False
 
 @tasks.bind()
@@ -20,7 +22,7 @@ def _say_goodbye(greeting, goodbye_message):
 
 
 @tasks.bind()
-def _fail():
+def _fail(*args):
     raise Exception('I am supposed to fail')
 
 
@@ -30,6 +32,19 @@ def _join_results(results):
     join_results_called = True
     return '; '.join(results)
 
+
+@tasks.bind()
+def _join_results2(results):
+    global join_results2_called
+    join_results2_called = True
+    return '; '.join(results)
+
+
+@tasks.bind()
+def _join_results3(results):
+    global join_results3_called
+    join_results3_called = True
+    return '; '.join(results)
 
 @tasks.bind(with_state=True)
 def _say_hello_with_state(initial_state, first_name, last_name):
@@ -57,6 +72,7 @@ class ParallelWorkflowTests(unittest.TestCase):
             _say_hello.send("John", "Smith"),
             _say_hello.send("Jane", "Doe").continue_with(_say_goodbye, goodbye_message="see you later!"),
         ]).continue_with(_join_results)
+
         result = self.test_harness.run_pipeline(pipeline)
 
         self.assertEqual(result, 'Hello John Smith; Hello Jane Doe. So now I will say see you later!')
@@ -74,15 +90,39 @@ class ParallelWorkflowTests(unittest.TestCase):
     def test_nested_parallel_workflow(self):
         pipeline = in_parallel([
             in_parallel([
-            _say_hello.send("John", "Smith"),
-            _say_hello.send("Jane", "Doe").continue_with(_say_goodbye, goodbye_message="see you later!")
+                in_parallel([
+                _say_hello.send("John", "Smith"),
+                _say_hello.send("Jane", "Doe").continue_with(_say_goodbye, goodbye_message="see you later!")
+                ]).continue_with(_join_results)
             ])
         ])
 
         result = self.test_harness.run_pipeline(pipeline)
 
-        self.assertEqual(result, [['Hello John Smith', 'Hello Jane Doe. So now I will say see you later!']])
+        print(result)
 
+        self.assertEqual(result, [['Hello John Smith; Hello Jane Doe. So now I will say see you later!']])
+
+    def test_nested_parallel_workflow_continuations(self):
+
+        pipeline = in_parallel([
+            in_parallel([
+                in_parallel([
+                _say_hello.send("John", "Smith"),
+                _say_hello.send("Jane", "Doe").continue_with(_say_goodbye, goodbye_message="see you later!")
+                ]).continue_with(_join_results)
+            ]).continue_with(_join_results2)
+        ]).continue_with(_join_results3)
+
+
+        result = self.test_harness.run_pipeline(pipeline)
+
+        print(result)
+
+        self.assertEqual(result, 'Hello John Smith; Hello Jane Doe. So now I will say see you later!')
+        self.assertEqual(join_results_called, True)
+        self.assertEqual(join_results2_called, True)
+        self.assertEqual(join_results3_called, True)
 
     def test_continuation_into_nested_parallel_workflow(self):
         pipeline = _say_hello.send("John", "Smith").continue_with(in_parallel([in_parallel([
@@ -109,6 +149,24 @@ class ParallelWorkflowTests(unittest.TestCase):
 
         self.assertEqual(join_results_called, False)
         self.assertEqual(say_goodbye_called, True)
+
+
+    def test_parallel_workflow_with_error_and_continuations(self):
+        global join_results_called
+        join_results_called = False
+        
+        pipeline = in_parallel([
+            _fail.send().continue_with(in_parallel([_say_hello.send("John", "Smith").continue_with(_join_results)])),  # this chain will fail at first step
+            _say_goodbye.send("John", "Bye") # this chain will proceed
+        ])
+
+        # overall we will get an exception
+
+        self.assertRaises(TaskErrorException, self.test_harness.run_pipeline, pipeline)
+
+        self.assertEqual(join_results_called, False)
+        self.assertEqual(say_goodbye_called, True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parallel_workflow.py
+++ b/tests/test_parallel_workflow.py
@@ -124,6 +124,28 @@ class ParallelWorkflowTests(unittest.TestCase):
         self.assertEqual(join_results2_called, True)
         self.assertEqual(join_results3_called, True)
 
+
+    def test_continuation_into_parallel_workflow(self):
+        pipeline = _say_hello.send("John", "Smith").continue_with(in_parallel([
+            _say_goodbye.send(goodbye_message="see you later!"),
+            _say_goodbye.send(goodbye_message="see you later!")
+        ]))
+
+        result = self.test_harness.run_pipeline(pipeline)
+
+        self.assertEqual(result, ['Hello John Smith. So now I will say see you later!', 'Hello John Smith. So now I will say see you later!'])
+
+    def test_continuation_into_parallel_workflow_with_contination(self):
+        pipeline = _say_hello.send("John", "Smith").continue_with(in_parallel([
+            _say_goodbye.send(goodbye_message="see you later!"),
+            _say_goodbye.send(goodbye_message="see you later!")
+        ]).continue_with(_join_results))
+
+        result = self.test_harness.run_pipeline(pipeline)
+
+        self.assertEqual(result, 'Hello John Smith. So now I will say see you later!; Hello John Smith. So now I will say see you later!')
+
+
     def test_continuation_into_nested_parallel_workflow(self):
         pipeline = _say_hello.send("John", "Smith").continue_with(in_parallel([in_parallel([
             _say_goodbye.send(goodbye_message="see you later!"),

--- a/tests/test_with_context.py
+++ b/tests/test_with_context.py
@@ -1,0 +1,33 @@
+import unittest
+
+from tests.utils import TestHarness, tasks
+
+
+
+@tasks.bind(with_context=True)
+def _with_context_and_arg_task(context, arg):
+    return str(type(context)), arg
+
+
+@tasks.bind(with_context=True, with_state=True)
+def _with_context_and_arg_and_state_task(context, state, arg):
+    return None, str(type(context)), arg
+
+
+class WithContextTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_harness = TestHarness()
+
+    def test_with_context_and_arg(self):
+        pipeline = tasks.send(_with_context_and_arg_task, 8)
+        result = self.test_harness.run_pipeline(pipeline)
+        self.assertEqual(result, ("<class 'statefun_tasks.context.TaskContext'>", 8))
+
+    def test_with_context_and_arg_and_state(self):
+        pipeline = tasks.send(_with_context_and_arg_and_state_task, 8)
+        result = self.test_harness.run_pipeline(pipeline)
+        self.assertEqual(result, ("<class 'statefun_tasks.context.TaskContext'>", 8))
+
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Exceptions thrown in in_parallel groups were not always emitted
Nested parallel workflows did not always invoke continations correctly
Pipeline helper functions were all recursive.  Switched to iterative equivalents for better performance.