### PR TITLE
Removing custom destinations from pipeline orchestrator tasks so that…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 
 setuptools.setup(
     name="statefun-tasks",
-    version="0.9.7",
+    version="0.9.8",
     author="Frans King",
     author_email="frans.king@sbbsystems.com",
     description="Tasks API for Stateful Functions on Flink",

--- a/statefun_tasks/pipeline_builder.py
+++ b/statefun_tasks/pipeline_builder.py
@@ -119,12 +119,9 @@ class PipelineBuilder(object):
 
     def get_destination(self):
         """
-        Returns the initial destination of the pipeline - i.e. where the first task should be sent 
-        or None if it should be set to the default namespace/worker
-
-        :return: the initial destination (e.g. example/worker) or None if it should use the default
+        Returns the initial destination of the pipeline as None - i.e. use the default ingress
         """
-        return None if not any(self._pipeline) else self._pipeline[0].get_destination()
+        return None
 
     def to_task_request(self, serialiser) -> TaskRequest:
         """

--- a/statefun_tasks/types.py
+++ b/statefun_tasks/types.py
@@ -47,6 +47,10 @@ class Task:
         self._proto = proto
 
     @staticmethod
+    def from_id(task_id, namespace=None, worker_name=None):
+        return Task(TaskEntry(task_id=task_id, namespace=namespace, worker_name=worker_name))
+
+    @staticmethod
     def from_fields(task_id, task_type, task_args, task_kwargs, is_finally=None, namespace=None, worker_name=None,
                     message_type=None, pipeline_address=None, pipeline_id=None, parent_task_address=None,
                     parent_task_id=None, is_fruitful=None, retry_policy=None, module_name=None, with_state=None,


### PR DESCRIPTION
… they always go to the same destination